### PR TITLE
OMS: Add service 'overlay' to service_contexts

### DIFF
--- a/service.te
+++ b/service.te
@@ -67,6 +67,7 @@ type netstats_service, system_api_service, system_server_service, service_manage
 type network_management_service, system_api_service, system_server_service, service_manager_type;
 type network_score_service, system_api_service, system_server_service, service_manager_type;
 type notification_service, app_api_service, system_server_service, service_manager_type;
+type overlay_service, app_api_service, system_server_service, service_manager_type;
 type package_service, app_api_service, system_server_service, service_manager_type;
 type permission_service, app_api_service, system_server_service, service_manager_type;
 type persistent_data_block_service, system_api_service, system_server_service, service_manager_type;

--- a/service_contexts
+++ b/service_contexts
@@ -81,6 +81,7 @@ network_management                        u:object_r:network_management_service:
 network_score                             u:object_r:network_score_service:s0
 nfc                                       u:object_r:nfc_service:s0
 notification                              u:object_r:notification_service:s0
+overlay                                   u:object_r:overlay_service:s0
 package                                   u:object_r:package_service:s0
 permission                                u:object_r:permission_service:s0
 persistent_data_block                     u:object_r:persistent_data_block_service:s0


### PR DESCRIPTION
The 'overlay' service is the Overlay Manager Service, which tracks
packages and their Runtime Resource Overlay overlay packages.

Change-Id: I43a5e364b730df7b8e1472db31da6fc8922ff46d
Co-authored-by: Martin Wallgren martin.wallgren@sonymobile.com
Signed-off-by: Zoran Jovanovic zoran.jovanovic@sonymobile.com
